### PR TITLE
Use TextField with ValueChangeMode.BLUR to make it able to cancel edit

### DIFF
--- a/GridFastNavigation-demo/src/main/java/org/vaadin/patrik/demo/DemoFastGrid.java
+++ b/GridFastNavigation-demo/src/main/java/org/vaadin/patrik/demo/DemoFastGrid.java
@@ -30,6 +30,7 @@ import com.vaadin.data.converter.StringToFloatConverter;
 import com.vaadin.data.converter.StringToIntegerConverter;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.event.ShortcutAction.KeyCode;
+import com.vaadin.shared.ui.ValueChangeMode;
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.DateField;
@@ -149,11 +150,11 @@ public class DemoFastGrid extends Grid<DemoColumns>
 	 */
 	private void bindColumnsToEditor()
 	{
-		TextField col1 = new TextField();
-		TextField col3 = new TextField();
-		TextField col4 = new TextField();
-		TextField col5 = new TextField();
-		TextField col6 = new TextField();
+		TextField col1 = createTextField(ValueChangeMode.BLUR);
+		TextField col3 = createTextField(ValueChangeMode.BLUR);
+		TextField col4 = createTextField(ValueChangeMode.BLUR);
+		TextField col5 = createTextField(ValueChangeMode.BLUR);
+		TextField col6 = createTextField(ValueChangeMode.BLUR);
 		DateTimeField col7 = new DateTimeField();
 		DateField col8 = new DateField();
 		CheckBox col9 = new CheckBox();
@@ -242,6 +243,12 @@ public class DemoFastGrid extends Grid<DemoColumns>
 		demoData.refreshAll();
 		this.setSelectionMode(SelectionMode.NONE);
 		this.setSizeFull();
+	}
+
+	private TextField createTextField(ValueChangeMode valueChangeMode) {
+		TextField textField = new TextField();
+		textField.setValueChangeMode(valueChangeMode);
+		return textField;
 	}
 
 	// Add a blank row to the grid and tell the grid to refresh itself showing the new row.


### PR DESCRIPTION
#19

Vaadin 8 `TextField` introduced different `ValueChangeMode`s that determine how often is a server round trip initiated with new value. By default `ValueChangeMode.LAZY` is used that sends the value to the server a defined time after the last value change.

When using the default setting with unbuffered mode, every time this value change happens, the change cannot be cancelled any more.

Setting `ValueChangeMode.BLUR` will keep the old value until a new cell is focused and can be cancelled when still editing the value.