### PR TITLE
Add Serializable to EventListenerList and Listener

### DIFF
--- a/GridFastNavigation-addon/src/main/java/org/vaadin/patrik/events/EventListenerList.java
+++ b/GridFastNavigation-addon/src/main/java/org/vaadin/patrik/events/EventListenerList.java
@@ -1,9 +1,10 @@
 package org.vaadin.patrik.events;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class EventListenerList<LISTENER extends Listener<EVENT>, EVENT> {
+public class EventListenerList<LISTENER extends Listener<EVENT>, EVENT> implements Serializable {
     private final List<LISTENER> listeners;
     
     public EventListenerList() {

--- a/GridFastNavigation-addon/src/main/java/org/vaadin/patrik/events/Listener.java
+++ b/GridFastNavigation-addon/src/main/java/org/vaadin/patrik/events/Listener.java
@@ -1,5 +1,7 @@
 package org.vaadin.patrik.events;
 
-public interface Listener<EventType> {
+import java.io.Serializable;
+
+public interface Listener<EventType> extends Serializable {
     public void onEvent(EventType event);
 }


### PR DESCRIPTION
Hi Tatu,

added Serializable to two classes in vaadin8 branch in order to prevent java.io.NotSerializableException from happening.

Kind regards
Karl